### PR TITLE
use config() instead of env() for recaptcha secret

### DIFF
--- a/src/ReCaptcha.php
+++ b/src/ReCaptcha.php
@@ -20,7 +20,7 @@ class ReCaptcha
                 config('recaptcha.verify_url'),
                 [
                     'form_params' => [
-                        'secret'   => env('RECAPTCHA_SECRET'),
+                        'secret'   => config('recaptcha.secret'),
                         'response' => $value,
                         'remoteip' => request()->ip(),
                     ],


### PR DESCRIPTION
env() should only be used in config files, so that the config may be cached correctly with `php artisan config:cache`

the problem was that when caching the config, no secret was sent to google, so google's response would be:

`{"success":false,"error-codes":["missing-input-secret"]}`